### PR TITLE
Refactor some codes as rust-clippy suggested

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,7 @@ handlebars = "~0.15.0"
 typemap = "~0.3.3"
 mime = "~0.1.3"
 mime_guess = "~1.5.0"
+
+[dependencies.clippy]
+optional = true
+version = "^0.*"

--- a/src/app.rs
+++ b/src/app.rs
@@ -19,8 +19,8 @@ use hyper::server::Response as HTTPResponse;
 
 use types::{
     PencilError,
-        PenHTTPError,
-        PenUserError,
+    PenHTTPError,
+    PenUserError,
 
     UserError,
     PencilResult,
@@ -82,7 +82,7 @@ fn default_config() -> Config {
     let mut config = Config::new();
     config.set("DEBUG", Json::Boolean(false));
     config.set("TESTING", Json::Boolean(false));
-    return config;
+    config
 }
 
 impl Pencil {
@@ -377,7 +377,7 @@ impl Pencil {
                 return Some(result);
             }
         }
-        return None;
+        None
     }
 
     /// Does the request dispatching.  Matches the URL and returns the return
@@ -391,10 +391,10 @@ impl Pencil {
         }
         match self.view_functions.get(&request.endpoint().unwrap()) {
             Some(&view_func) => {
-                return view_func(request);
+                view_func(request)
             },
             None => {
-                return Err(PenHTTPError(NotFound));
+                Err(PenHTTPError(NotFound))
             }
         }
     }
@@ -608,7 +608,7 @@ impl PathBound for Pencil {
     fn open_resource(&self, resource: &str) -> File {
         let mut pathbuf = PathBuf::from(&self.root_path);
         pathbuf.push(resource);
-        return File::open(&pathbuf.as_path()).unwrap();
+        File::open(&pathbuf.as_path()).unwrap()
     }
 }
 
@@ -631,5 +631,5 @@ fn send_app_static_file(request: &mut Request) -> PencilResult {
     static_path.push(&request.app.static_folder);
     let static_path_str = static_path.to_str().unwrap();
     let filename = request.view_args.get("filename").unwrap();
-    return send_from_directory(static_path_str, filename, false);
+    send_from_directory(static_path_str, filename, false)
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -71,7 +71,7 @@ pub fn safe_join(directory: &str, filename: &str) -> Option<PathBuf> {
 /// One helper function that can be used to return HTTP Error inside a view function.
 pub fn abort(code: u16) -> PencilResult {
     let error = HTTPError::new(code);
-    return Err(PenHTTPError(error));
+    Err(PenHTTPError(error))
 }
 
 
@@ -87,14 +87,16 @@ pub fn redirect(location: &str, code: u16) -> PencilResult {
     response.status_code = code;
     response.set_content_type("text/html");
     response.headers.set(Location(location.to_string()));
-    return Ok(response);
+    Ok(response)
 }
 
 
 /// Replace special characters "&", "<", ">" and (") to HTML-safe characters.
 pub fn escape(s: String) -> String {
-    return s.replace("&", "&amp;").replace("<", "&lt;")
-            .replace(">", "&gt;").replace("\"", "&quot;");
+    s.replace("&", "&amp;")
+     .replace("<", "&lt;")
+     .replace(">", "&gt;")
+     .replace("\"", "&quot;")
 }
 
 
@@ -133,7 +135,7 @@ pub fn send_file(filepath: &str, mimetype: Mime, as_attachment: bool) -> PencilR
             }
         }
     }
-    return Ok(response);
+    Ok(response)
 }
 
 
@@ -147,15 +149,15 @@ pub fn send_from_directory(directory: &str, filename: &str,
             let mimetype = guess_mime_type(filepath.as_path());
             match filepath.as_path().to_str() {
                 Some(filepath) => {
-                    return send_file(filepath, mimetype, as_attachment);
+                    send_file(filepath, mimetype, as_attachment)
                 },
                 None => {
-                    return Err(PenHTTPError(NotFound));
+                    Err(PenHTTPError(NotFound))
                 }
             }
         },
         None => {
-            return Err(PenHTTPError(NotFound));
+            Err(PenHTTPError(NotFound))
         }
     }
 }

--- a/src/http_errors.rs
+++ b/src/http_errors.rs
@@ -239,7 +239,7 @@ impl HTTPError {
             },
             _ => {}
         }
-        return response;
+        response
     }
 }
 

--- a/src/httputils.rs
+++ b/src/httputils.rs
@@ -8,7 +8,7 @@ use hyper::status::StatusCode;
 /// Get HTTP status name by status code.
 pub fn get_name_by_http_code(code: u16) -> Option<&'static str> {
     let status_code = get_status_from_code(code);
-    return status_code.canonical_reason();
+    status_code.canonical_reason()
 }
 
 
@@ -22,7 +22,7 @@ pub fn get_content_type(mimetype: &str, charset: &str) -> String {
             return content_type;
         }
     }
-    return mimetype.to_string();
+    mimetype.to_string()
 }
 
 

--- a/src/json.rs
+++ b/src/json.rs
@@ -34,11 +34,11 @@ pub fn jsonify<T: Encodable>(object: &T) -> PencilResult {
         Ok(encoded) => {
             let mut response = Response::from(encoded);
             response.set_content_type("application/json");
-            return Ok(response);
+            Ok(response)
         },
         Err(err) => {
             let error = UserError::new(format!("Json encoder error: {}", err));
-            return Err(PenUserError(error));
+            Err(PenUserError(error))
         },
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,10 @@
        html_root_url = "http://fengsp.github.io/pencil/")]
 
 #![deny(non_camel_case_types)]
+#![cfg_attr(feature="clippy", feature(plugin))]
+#![cfg_attr(feature="clippy", plugin(clippy))]
+#![cfg_attr(feature="clippy", deny(clippy))]
+#![cfg_attr(feature="clippy", warn(cyclomatic_complexity))]
 
 #[macro_use]
 extern crate log;

--- a/src/module.rs
+++ b/src/module.rs
@@ -181,5 +181,5 @@ fn send_module_static_file(request: &mut Request) -> PencilResult {
             }
         }
     }
-    return Err(NotFound.into());
+    Err(NotFound.into())
 }

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -60,7 +60,7 @@ fn parse_rule(rule: &str) -> Vec<(Option<&str>, &str)> {
         }
         rule_parts.push((None, remaining));
     }
-    return rule_parts;
+    rule_parts
 }
 
 /// The matcher holds the url regex object.
@@ -166,11 +166,11 @@ impl Rule {
         if all_methods.contains(&Method::Get) {
             all_methods.insert(Method::Head);
         }
-        let provide_automatic_options = if !all_methods.contains(&Method::Options) {
+        let provide_automatic_options = if all_methods.contains(&Method::Options) {
+            false
+        } else {
             all_methods.insert(Method::Options);
             true
-        } else {
-            false
         };
         Rule {
             matcher: matcher,
@@ -274,7 +274,7 @@ impl<'m> MapAdapter<'m> {
             allowed_methods.extend(have_match_for.into_iter());
             return Err(MethodNotAllowed(Some(allowed_methods)))
         }
-        return Err(NotFound)
+        Err(NotFound)
     }
 
     /// Get the valid methods that match for the given path.

--- a/src/templating.rs
+++ b/src/templating.rs
@@ -20,7 +20,7 @@ use wrappers::Response;
 
 impl convert::From<RenderError> for PencilError {
     fn from(err: RenderError) -> PencilError {
-        return PenUserError(UserError::new(&err.desc));
+        PenUserError(UserError::new(&err.desc))
     }
 }
 
@@ -31,7 +31,7 @@ pub fn render_template<T: ToJson>(app: &Pencil, template_name: &str, context: &T
     }
     let registry = registry_read_rv.unwrap();
     let rv = try!(registry.render(template_name, context));
-    return Ok(Response::from(rv));
+    Ok(Response::from(rv))
 }
 
 struct StringWriter {
@@ -153,5 +153,5 @@ pub fn load_template(app: &Pencil, template_name: &str) -> Option<IOResult<Strin
             }
         }
     }
-    return None;
+    None
 }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -19,7 +19,7 @@ impl<'c> PencilClient<'c> {
     /// Get wrapped application.
     #[allow(dead_code)]
     pub fn get_application(&self) -> &Pencil {
-        return self.application;
+        self.application
     }
 
     /// Runs the wrapped pencil app with the given request.

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -121,7 +121,7 @@ impl<'r, 'a, 'b: 'a> Request<'r, 'a, 'b> {
             }
             self.args = Some(args);
         }
-        return self.args.as_ref().unwrap();
+        self.args.as_ref().unwrap()
     }
 
     /// Get content type.
@@ -147,7 +147,7 @@ impl<'r, 'a, 'b: 'a> Request<'r, 'a, 'b> {
             };
             self.cached_json = Some(rv);
         }
-        return self.cached_json.as_ref().unwrap();
+        self.cached_json.as_ref().unwrap()
     }
 
     /// This method is used internally to retrieve submitted data.
@@ -203,9 +203,9 @@ impl<'r, 'a, 'b: 'a> Request<'r, 'a, 'b> {
         let path = self.path();
         let query_string = self.query_string();
         if path.is_some() && query_string.is_some() {
-            return Some(path.unwrap() + "?" + &query_string.unwrap());
+            Some(path.unwrap() + "?" + &query_string.unwrap())
         } else  {
-            return path;
+            path
         }
     }
 
@@ -404,7 +404,7 @@ impl Response {
         let mime: Mime = "text/html; charset=UTF-8".parse().unwrap();
         let content_type = ContentType(mime);
         response.headers.set(content_type);
-        return response;
+        response
     }
 
     /// Create an empty response without body.
@@ -503,7 +503,7 @@ impl convert::From<Vec<u8>> for Response {
         let content_length = bytes.len();
         let mut response = Response::new(bytes);
         response.set_content_length(content_length);
-        return response;
+        response
     }
 }
 
@@ -545,6 +545,6 @@ impl convert::From<File> for Response {
         if let Some(content_length) = content_length {
             response.set_content_length(content_length as usize);
         }
-        return response;
+        response
     }
 }


### PR DESCRIPTION
```bash
multirust run nightly cargo build --features clippy
```

One issue remains.

```
src/types.rs:47:1: 50:2 error: All variants have the same prefix: `Pen`
src/types.rs:47 pub enum PencilError {
src/types.rs:48     PenHTTPError(HTTPError),
src/types.rs:49     PenUserError(UserError),
src/types.rs:50 }
src/lib.rs:50:36: 50:42 note: lint level defined here
src/lib.rs:50 #![cfg_attr(feature="clippy", deny(clippy))]
                                                 ^~~~~~
src/types.rs:47:1: 50:2 help: remove the prefixes and use full paths to the variants instead of glob imports
for further information visit https://github.com/Manishearth/rust-clippy/wiki#enum_variant_names
```