### PR TITLE
Allow passing closures to routes.

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -24,7 +24,6 @@ use types::{
 
     UserError,
     PencilResult,
-    ViewFunc,
     HTTPErrorHandler,
     UserErrorHandler,
     BeforeRequestFunc,
@@ -70,7 +69,7 @@ pub struct Pencil {
     /// All the attached modules in a hashmap by name.
     pub modules: HashMap<String, Module>,
     /// A dictionary of all view functions registered.  The key will be endpoint.
-    view_functions: HashMap<String, ViewFunc>,
+    view_functions: HashMap<String, Box<Fn(&mut Request) -> PencilResult + Send + Sync>>,
     before_request_funcs: Vec<BeforeRequestFunc>,
     after_request_funcs: Vec<AfterRequestFunc>,
     teardown_request_funcs: Vec<TeardownRequestFunc>,
@@ -162,45 +161,45 @@ impl Pencil {
     ///
     /// A rule that listens for `GET` will implicitly listen for `HEAD`.
     ///
-    pub fn route<M: Into<Matcher>, N: AsRef<[Method]>>(&mut self, rule: M, methods: N, endpoint: &str, view_func: ViewFunc) {
+    pub fn route<M: Into<Matcher>, N: AsRef<[Method]>, F: Fn(&mut Request) -> PencilResult>(&mut self, rule: M, methods: N, endpoint: &str, view_func: F) where F: Send + Sync + 'static {
         self.add_url_rule(rule.into(), methods.as_ref(), endpoint, view_func);
     }
 
     /// This is a shortcut for `route`, register a view function for
     /// a given URL rule with just `GET` method (implicitly `HEAD`).
-    pub fn get<M: Into<Matcher>>(&mut self, rule: M, endpoint: &str, view_func: ViewFunc) {
+    pub fn get<M: Into<Matcher>, F: Fn(&mut Request) -> PencilResult>(&mut self, rule: M, endpoint: &str, view_func: F) where F: Send + Sync + 'static {
         self.route(rule, &[Method::Get], endpoint, view_func);
     }
 
     /// This is a shortcut for `route`, register a view function for
     /// a given URL rule with just `POST` method.
-    pub fn post<M: Into<Matcher>>(&mut self, rule: M, endpoint: &str, view_func: ViewFunc) {
+    pub fn post<M: Into<Matcher>, F: Fn(&mut Request) -> PencilResult>(&mut self, rule: M, endpoint: &str, view_func: F) where F: Send + Sync + 'static {
         self.route(rule, &[Method::Post], endpoint, view_func);
     }
 
     /// This is a shortcut for `route`, register a view function for
     /// a given URL rule with just `DELETE` method.
-    pub fn delete<M: Into<Matcher>>(&mut self, rule: M, endpoint: &str, view_func: ViewFunc) {
+    pub fn delete<M: Into<Matcher>, F: Fn(&mut Request) -> PencilResult>(&mut self, rule: M, endpoint: &str, view_func: F) where F: Send + Sync + 'static {
         self.route(rule, &[Method::Delete], endpoint, view_func);
     }
 
     /// This is a shortcut for `route`, register a view function for
     /// a given URL rule with just `PATCH` method.
-    pub fn patch<M: Into<Matcher>>(&mut self, rule: M, endpoint: &str, view_func: ViewFunc) {
+    pub fn patch<M: Into<Matcher>, F: Fn(&mut Request) -> PencilResult>(&mut self, rule: M, endpoint: &str, view_func: F) where F: Send + Sync + 'static {
         self.route(rule, &[Method::Patch], endpoint, view_func);
     }
 
     /// This is a shortcut for `route`, register a view function for
     /// a given URL rule with just `PUT` method.
-    pub fn put<M: Into<Matcher>>(&mut self, rule: M, endpoint: &str, view_func: ViewFunc) {
+    pub fn put<M: Into<Matcher>, F: Fn(&mut Request) -> PencilResult>(&mut self, rule: M, endpoint: &str, view_func: F) where F: Send + Sync + 'static {
         self.route(rule, &[Method::Put], endpoint, view_func);
     }
 
     /// Connects a URL rule.
-    pub fn add_url_rule(&mut self, matcher: Matcher, methods: &[Method], endpoint: &str, view_func: ViewFunc) {
+    pub fn add_url_rule<F: Fn(&mut Request) -> PencilResult>(&mut self, matcher: Matcher, methods: &[Method], endpoint: &str, view_func: F) where F: Send + Sync + 'static {
         let url_rule = Rule::new(matcher, methods, endpoint);
         self.url_map.add(url_rule);
-        self.view_functions.insert(endpoint.to_string(), view_func);
+        self.view_functions.insert(endpoint.to_string(), Box::new(view_func));
     }
 
     /// Register a module on the application.
@@ -390,7 +389,7 @@ impl Pencil {
             return Ok(default_options_response);
         }
         match self.view_functions.get(&request.endpoint().unwrap()) {
-            Some(&view_func) => {
+            Some(ref view_func) => {
                 return view_func(request);
             },
             None => {

--- a/src/types.rs
+++ b/src/types.rs
@@ -97,7 +97,6 @@ pub type ViewArgs = HashMap<String, String>;
 /// View function type.
 pub type ViewFunc = fn(&mut Request) -> PencilResult;
 
-
 /// HTTP Error handler type.
 pub type HTTPErrorHandler = fn(HTTPError) -> PencilResult;
 /// User Error handler type.


### PR DESCRIPTION
While trying pencil, I almost immediately wanted to pass closures to the route functions instead of function pointers.  In particular, this allows for capturing config information loaded at startup (eg api keys).

There are more places that take function pointers which should probably also be changed before this is merged, but I wanted to get your feedback first.