### PR TITLE
Add ability to set thread count.

### DIFF
--- a/src/serving.rs
+++ b/src/serving.rs
@@ -1,5 +1,8 @@
 //! This module implements the http server support for our application.
 
+use std::env;
+use std::str::FromStr;
+
 use std::net::ToSocketAddrs;
 
 use hyper::server::Server;
@@ -9,6 +12,9 @@ use app::Pencil;
 
 /// Run the `Pencil` application.
 pub fn run_server<A: ToSocketAddrs>(application: Pencil, addr: A) {
+    let threads_str = env::var("THREADS").unwrap_or(String::new());
+    let threads = FromStr::from_str(&threads_str).unwrap_or(10) as usize;
+
     let server = Server::http(addr).unwrap();
-    let _guard = server.handle(application).unwrap();
+    let _guard = server.handle_threads(application,threads).unwrap();
 }


### PR DESCRIPTION
Uses `handle` instead of `handle_threads`.
This change will allow the env var `THREADS` to be set with a thread count value, or it will default to 10.
http://docs.maidsafe.net/crust/master/hyper/server/struct.Server.html#method.handle_threads

```
> cargo run
   Compiling project v0.1.0 (file:///path)
     Running `target/debug/file`
DEBUG:file: Listening at 127.0.0.1:5000 (root: /path).
DEBUG:hyper::server: threads = 10

> THREADS=15 cargo run
     Running `target/debug/file`
DEBUG:file: Listening at 127.0.0.1:5000 (root: /path).
DEBUG:hyper::server: threads = 15

-> % THREADS=a cargo run
     Running `target/debug/file`
DEBUG:file: Listening at 127.0.0.1:5000 (root: /path/).
DEBUG:hyper::server: threads = 10
```
