### PR TITLE
Use serde and serde_json instead of rustc_serialize.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,14 @@ ssl = ["hyper/ssl", "formdata/ssl"]
 
 [dependencies]
 regex = "0.1.77"
-rustc-serialize = "0.3.19"
 url = "1.2.1"
 log = "0.3.6"
-handlebars = "0.16.1"
+handlebars = { version = "0.21", features = ["serde_type"] }
 typemap = "0.3.3"
 mime = "0.2.2"
 mime_guess = "1.8.0"
+serde = "0.8"
+serde_json = "0.8"
 
 [dependencies.hyper]
 version = "0.9.10"

--- a/src/app.rs
+++ b/src/app.rs
@@ -9,8 +9,8 @@ use std::fs::File;
 use std::path::PathBuf;
 use std::net::ToSocketAddrs;
 
-use rustc_serialize::json::Json;
-use rustc_serialize::json::ToJson;
+use serde::Serialize;
+use serde_json::Value;
 use handlebars::Handlebars;
 use hyper;
 use hyper::method::Method;
@@ -81,8 +81,8 @@ pub struct Pencil {
 
 fn default_config() -> Config {
     let mut config = Config::new();
-    config.set("DEBUG", Json::Boolean(false));
-    config.set("TESTING", Json::Boolean(false));
+    config.set("DEBUG", Value::Bool(false));
+    config.set("TESTING", Value::Bool(false));
     config
 }
 
@@ -136,14 +136,14 @@ impl Pencil {
     /// with the `DEBUG` configuration key.  Set this to `True` to
     /// enable debugging of the application.
     pub fn set_debug(&mut self, flag: bool) {
-        self.config.set("DEBUG", Json::Boolean(flag));
+        self.config.set("DEBUG", Value::Bool(flag));
     }
 
     /// Set the testing flag.  This field is configured from the config
     /// with the `TESTING` configuration key.  Set this to `True` to
     /// enable the test mode of the application.
     pub fn set_testing(&mut self, flag: bool) {
-        self.config.set("TESTING", Json::Boolean(flag));
+        self.config.set("TESTING", Value::Bool(flag));
     }
 
     /// Set global log level based on the application's debug flag.
@@ -553,7 +553,7 @@ impl Pencil {
     /// Renders a template from the template folder with the given context.
     /// The template name is the name of the template to be rendered.
     /// The context is the variables that should be available in the template.
-    pub fn render_template<T: ToJson>(&self, template_name: &str, context: &T) -> PencilResult {
+    pub fn render_template<T: Serialize>(&self, template_name: &str, context: &T) -> PencilResult {
         render_template(self, template_name, context)
     }
 
@@ -562,7 +562,7 @@ impl Pencil {
     /// with the given context.
     /// The source is the sourcecode of the template to be rendered.
     /// The context is the variables that should be available in the template.
-    pub fn render_template_string<T: ToJson>(&self, source: &str, context: &T) -> PencilResult {
+    pub fn render_template_string<T: Serialize>(&self, source: &str, context: &T) -> PencilResult {
         render_template_string(self, source, context)
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,8 +6,10 @@ use std::io::Read;
 use std::fs::File;
 use std::path::Path;
 use std::collections::BTreeMap;
-use rustc_serialize::json::{Object, Json};
+use serde_json::{Value, self};
+use serde_json::value::Map;
 
+pub type Object = Map<String, Value>;   
 
 /// The pencil `Config` type, We provide ways to fill it from JSON files:
 ///
@@ -32,7 +34,7 @@ use rustc_serialize::json::{Object, Json};
 /// ```
 #[derive(Clone)]
 pub struct Config {
-    config: Object,
+    config: Map<String, Value>,
 }
 
 impl Default for Config {
@@ -51,12 +53,12 @@ impl Config {
     }
 
     /// Set a value for the key.
-    pub fn set(&mut self, key: &str, value: Json) {
+    pub fn set(&mut self, key: &str, value: Value) {
         self.config.insert(key.to_string(), value);
     }
 
     /// Returns a reference to the value corresponding to the key.
-    pub fn get(&self, key: &str) -> Option<&Json> {
+    pub fn get(&self, key: &str) -> Option<&Value> {
         self.config.get(&key.to_string())
     }
 
@@ -67,7 +69,7 @@ impl Config {
         match self.get(key) {
             Some(value) => {
                 match *value {
-                    Json::Boolean(value) => value,
+                    Value::Bool(value) => value,
                     _ => default
                 }   
             },  
@@ -90,9 +92,9 @@ impl Config {
         let mut file = File::open(&path).unwrap();
         let mut content = String::new();
         file.read_to_string(&mut content).unwrap();
-        let object: Json = Json::from_str(&content).unwrap();
+        let object: Value = serde_json::from_str(&content).unwrap();
         match object {
-            Json::Object(object) => { self.from_object(object); },
+            Value::Object(object) => { self.from_object(object); },
             _ => { panic!("The configuration file is not an JSON object."); }
         }
     }

--- a/src/json.rs
+++ b/src/json.rs
@@ -1,7 +1,10 @@
 //! This module implements helpers for the JSON support in Pencil.
 
-use rustc_serialize::json;
-use rustc_serialize::Encodable;
+// use rustc_serialize::json;
+// use rustc_serialize::Encodable;
+
+use serde::Serialize;
+use serde_json;
 
 use wrappers::{Response};
 use types::{PencilResult, PenUserError, UserError};
@@ -29,8 +32,8 @@ use types::{PencilResult, PenUserError, UserError};
 ///     return jsonify(&user);
 /// }
 /// ```
-pub fn jsonify<T: Encodable>(object: &T) -> PencilResult {
-    match json::encode(object) {
+pub fn jsonify<T: Serialize>(object: &T) -> PencilResult {
+    match serde_json::to_string(object) {
         Ok(encoded) => {
             let mut response = Response::from(encoded);
             response.set_content_type("application/json");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,6 @@
 #[macro_use]
 extern crate log;
 extern crate hyper;
-extern crate rustc_serialize;
 extern crate regex;
 extern crate url;
 extern crate formdata;
@@ -57,6 +56,8 @@ extern crate handlebars;
 extern crate typemap;
 extern crate mime;
 extern crate mime_guess;
+extern crate serde;
+extern crate serde_json;    
 
 /* public api */
 pub use app::Pencil;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,7 +1,7 @@
 //! This module implements the logging support for Pencil.
 
 use std::env;
-use rustc_serialize::json::Json;
+use serde_json::Value;
 
 use app::Pencil;
 
@@ -10,7 +10,7 @@ use app::Pencil;
 /// This is only useful for `env_logger` crate.
 pub fn set_log_level(app: &Pencil) {
     if let Some(value) = app.config.get("DEBUG") {
-        if let Json::Boolean(value) = *value {
+        if let Value::Bool(value) = *value {
             if value {
                 env::set_var("RUST_LOG", "debug");
             }

--- a/src/templating.rs
+++ b/src/templating.rs
@@ -6,7 +6,7 @@ use std::fs::File;
 use std::path::PathBuf;
 use std::error::Error;
 
-use rustc_serialize::json::ToJson;
+use serde::Serialize;
 use handlebars::{RenderError, TemplateRenderError};
 
 use app::Pencil;
@@ -25,7 +25,7 @@ impl convert::From<TemplateRenderError> for PencilError {
     }
 }
 
-pub fn render_template<T: ToJson>(app: &Pencil, template_name: &str, context: &T) -> PencilResult {
+pub fn render_template<T: Serialize>(app: &Pencil, template_name: &str, context: &T) -> PencilResult {
     let registry_read_rv = app.handlebars_registry.read();
     if registry_read_rv.is_err() {
         return Err(PenUserError(UserError::new("Can't acquire handlebars registry")));
@@ -35,7 +35,7 @@ pub fn render_template<T: ToJson>(app: &Pencil, template_name: &str, context: &T
     Ok(Response::from(rv))
 }
 
-pub fn render_template_string<T: ToJson>(app: &Pencil, source: &str, context: &T) -> PencilResult {
+pub fn render_template_string<T: Serialize>(app: &Pencil, source: &str, context: &T) -> PencilResult {
     let registry_read_rv = app.handlebars_registry.read();
     if registry_read_rv.is_err() {
         return Err(PenUserError(UserError::new("Can't acquire handlebars registry")));

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -20,7 +20,7 @@ use hyper::buffer::BufReader;
 use url::Url;
 use url::form_urlencoded;
 use formdata::FilePart;
-use rustc_serialize::json;
+use serde_json;
 use typemap::TypeMap;
 
 use app::Pencil;
@@ -60,7 +60,7 @@ pub struct Request<'r, 'a, 'b: 'a> {
     args: Option<MultiDict<String>>,
     form: Option<MultiDict<String>>,
     files: Option<MultiDict<FilePart>>,
-    cached_json: Option<Option<json::Json>>
+    cached_json: Option<Option<serde_json::Value>>
 }
 
 impl<'r, 'a, 'b: 'a> Request<'r, 'a, 'b> {
@@ -171,12 +171,12 @@ impl<'r, 'a, 'b: 'a> Request<'r, 'a, 'b> {
     }
 
     /// Parses the incoming JSON request data.
-    pub fn get_json(&mut self) -> &Option<json::Json> {
+    pub fn get_json(&mut self) -> &Option<serde_json::Value> {
         if self.cached_json.is_none() {
             let mut data = String::from("");
             let rv = match self.read_to_string(&mut data) {
                 Ok(_) => {
-                    match json::Json::from_str(&data) {
+                    match serde_json::from_str(&data) {
                         Ok(json) => Some(json),
                         Err(_) => None
                     }

--- a/tests/test_config.rs
+++ b/tests/test_config.rs
@@ -1,21 +1,22 @@
 // Test the configuration.
 
 extern crate pencil;
-extern crate rustc_serialize as serialize;
+extern crate serde;
+extern crate serde_json;
 
 use std::env;
 use std::collections::BTreeMap;
-use serialize::json;
-use serialize::json::ToJson;
 
+use serde_json::{Value};
+use serde_json::value::{Map, ToJson};
 use pencil::Pencil;
 
 
 fn config_test(app: Pencil) {
     let test_key = app.config.get("TEST_KEY").unwrap();
     let secret_key = app.config.get("SECRET_KEY").unwrap();
-    assert!(test_key.as_string().unwrap() == "foo");
-    assert!(secret_key.as_string().unwrap() == "mysecret");
+    assert!(test_key.as_str().unwrap() == "foo");
+    assert!(secret_key.as_str().unwrap() == "mysecret");
     assert!(app.config.get("MISSING_KEY") == None);
 }
 
@@ -32,7 +33,7 @@ fn test_config_basic_set() {
 #[test]
 fn test_config_from_object() {
     let mut app = Pencil::new("/test");
-    let mut object: json::Object = BTreeMap::new();
+    let mut object: Map<String, Value> = BTreeMap::new();
     object.insert("TEST_KEY".to_string(), "foo".to_string().to_json());
     object.insert("SECRET_KEY".to_string(), "mysecret".to_string().to_json());
     app.config.from_object(object);


### PR DESCRIPTION
I've replaced rustc_serialize (which is not seeing much, if any, new development) with serde and serde_json. Tests are passing on my machine, the change was actually pretty painless and quick. 

That said, this is still probably a breaking change (I haven't looked at how much of rustc_serialize, if any, was exported through this library) and I haven't changed the docs yet to reflect the change.
