### PR TITLE
breaking: change the signature of after request functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,6 @@ homepage = "https://github.com/fengsp/pencil"
 documentation = "http://fengsp.github.io/pencil/"
 description = "A micro web framework for Rust."
 
-[features]
-default = ["ssl"]
-ssl = ["hyper/ssl", "formdata/ssl"]
-
 [dependencies]
 regex = "0.1.77"
 rustc-serialize = "0.3.19"
@@ -25,9 +21,9 @@ mime = "0.2.2"
 mime_guess = "1.8.0"
 
 [dependencies.hyper]
-version = "0.9.10"
+version = "0.10"
 default_features = false
 
 [dependencies.formdata]
-version = "0.11.0"
+version = "0.12.1"
 default_features = false

--- a/src/app.rs
+++ b/src/app.rs
@@ -428,7 +428,7 @@ impl Pencil {
     }
 
     /// Modify the response object before it's sent to the HTTP server.
-    fn process_response(&self, request: &Request, response: &mut Response) {
+    fn process_response(&self, mut request: &mut Request, response: &mut Response) {
         if let Some(module) = self.get_module(request.module_name()) {
             for func in module.after_request_funcs.iter().rev() {
                 func(request, response);
@@ -505,7 +505,7 @@ impl Pencil {
 
     /// Dispatches the request and performs request pre and postprocessing
     /// as well as HTTP error handling and User error handling.
-    fn full_dispatch_request(&self, request: &mut Request) -> Result<Response, PencilError> {
+    fn full_dispatch_request(&self, mut request: &mut Request) -> Result<Response, PencilError> {
         let result = match self.preprocess_request(request) {
             Some(result) => result,
             None => self.dispatch_request(request),
@@ -516,7 +516,7 @@ impl Pencil {
         };
         match rv {
             Ok(mut response) => {
-                self.process_response(request, &mut response);
+                self.process_response(&mut request, &mut response);
                 Ok(response)
             },
             Err(e) => Err(e),

--- a/src/app.rs
+++ b/src/app.rs
@@ -431,11 +431,11 @@ impl Pencil {
     fn process_response(&self, request: &Request, response: &mut Response) {
         if let Some(module) = self.get_module(request.module_name()) {
             for func in module.after_request_funcs.iter().rev() {
-                func(response);
+                func(request, response);
             }
         }
         for func in self.after_request_funcs.iter().rev() {
-            func(response);
+            func(request, response);
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@ pub mod config;
 pub mod helpers;
 pub mod method;
 mod testing;
-mod app;
+pub mod app;
 mod types;
 mod logging;
 mod serving;

--- a/src/types.rs
+++ b/src/types.rs
@@ -109,7 +109,7 @@ pub type BeforeRequestFunc = fn(&mut Request) -> Option<PencilResult>;
 
 
 /// After request func type.
-pub type AfterRequestFunc = fn(&Request, &mut Response);
+pub type AfterRequestFunc = fn(&mut Request, &mut Response);
 
 
 /// Teardown request func type.

--- a/src/types.rs
+++ b/src/types.rs
@@ -109,7 +109,7 @@ pub type BeforeRequestFunc = fn(&mut Request) -> Option<PencilResult>;
 
 
 /// After request func type.
-pub type AfterRequestFunc = fn(&mut Response);
+pub type AfterRequestFunc = fn(&Request, &mut Response);
 
 
 /// Teardown request func type.


### PR DESCRIPTION
The AfterRequestFunc type signature  is now `fn(&Request, &mut Response)`. This change allows information from the request to be used in typical post-request tasks such as logging in a standard format or reporting request timings. Specifically I needed to log in the Apache common log format, which includes request info, the response status code, and the size of the response body in bytes.